### PR TITLE
Refactor datapackage naming

### DIFF
--- a/python-execution-base/README.md
+++ b/python-execution-base/README.md
@@ -1,5 +1,5 @@
 To run:
 
 ```
-docker run -it -v ${DATAPACKAGE_PATH}:/usr/src/app/datapackage -e ALGORITHM=bindfit -e CONTAINER=ods/python-execution-base:v1 -e ARGUMENTS=bindfit.default ods/python-execution-base:v1
+docker run -it -v ${DATAPACKAGE_PATH}:/usr/src/app/datapackage -e CONFIGURATION=bindfit.default ods/python-execution-base:v1
 ```


### PR DESCRIPTION
Rename datapackage directories and some resource keys for clarity.

### Directories
- `pages` -> `interfaces`
- `arguments` -> `configurations`
- `metaschemas` -> `formats`

### Keys
- `algorithm.json: interface` -> `signature`
- `params resources: "schema": "metaschema"` -> `"schema": "inherit-from-format"`

See also: https://github.com/opendatastudio/opendatapy/pull/14, https://github.com/opendatastudio/cli/pull/13